### PR TITLE
Feature/replay

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -89,7 +89,6 @@
         ],
         "indent": "error",
         "indent-legacy": "error",
-        "init-declarations": "error",
         "jsx-quotes": "error",
         "key-spacing": "error",
         "keyword-spacing": [
@@ -162,7 +161,9 @@
         "no-lone-blocks": "error",
         "no-lonely-if": "error",
         "no-loop-func": "error",
-        "no-magic-numbers": "error",
+        "no-magic-numbers": ["warn", {
+            "ignore": [ 0, 1 ]
+        }],
         "no-mixed-operators": "error",
         "no-mixed-requires": "error",
         "no-multi-assign": "error",

--- a/index.js
+++ b/index.js
@@ -2,9 +2,11 @@
 const InputManager = require('./src/Manager');
 const GameStateEnums = require('./src/utils/GameStateEnums');
 const GameStateController = require('./src/GameStateController');
+const ActionEvent = require('./src/utils/ActionEvent');
 
 module.exports = {
     InputManager,
     GameStateEnums,
-    GameStateController
+    GameStateController,
+    ActionEvent
 };

--- a/localTesting/index.html
+++ b/localTesting/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <title>Input Manager Testing</title>
     <link rel="stylesheet" type="text/css" href="style.css">
-    <script src="bundle.js"></script>
 </head>
 <body>
 
@@ -12,7 +11,15 @@
     <h2>Input manager testing page. Click inside box and press buttons.</h2>
     <p>Check console for information.</p>
     <div id="input-manager-insertion"></div>
+    <h3>Current Time</h3>
+    <h4 id="real-time">0</h4>
+
+    <h3>Last action Time</h3>
+    <h4 id="action-time">0</h4>
+
+    <button id="test-replay-btn">Start Replay</button>
 </div>
 
 </body>
+<script src="bundle.js"></script>
 </html>

--- a/localTesting/server.js
+++ b/localTesting/server.js
@@ -3,6 +3,7 @@
 const express = require('express'),
     path = require('path'),
     http = require('http'),
+    fetch = require('node-fetch'),
     app = express(),
     port = 4545;
 
@@ -10,12 +11,23 @@ const express = require('express'),
 app.use(express.static(path.join(__dirname, '/')));
 
 // basic get stuff
-app.get('/', function(req, res) {
-    res.sendFile(path.join(__dirname + '/index.html'));
+app.get('/', (req, res) => {
+    res.sendFile(path.join(`${__dirname}/index.html`));
 });
 
-let server = http.createServer(app);
+// demo session
+app.get('/demo-session', (req, res) => {
+    fetch('https://api.leogons.com/tm/session/14')
+        .then(response => response.json())
+        .then(json => {
+            console.log(json);
+            res.send(json);
+        })
+        .catch(err => console.error(err));
+});
 
-server.listen(port, function () {
-    console.log("Test is running on port: " + port);
+const server = http.createServer(app);
+
+server.listen(port, () => {
+    console.log(`Test is running on port: ${port}`);
 });

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "express": "^4.17.1",
     "http": "0.0.0",
     "jsdoc-to-markdown": "^5.0.1",
+    "node-fetch": "^2.6.0",
     "path": "^0.12.7",
     "watchify": "^3.11.1"
   }

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -90,7 +90,7 @@ class Manager {
     }
 
     /**
-     * Toggles whether inputs are emitted;
+     * Toggles whether real time user inputs are emitted; Replay is not affected by this flag.
      */
     toggleEmissions() {
         this._emitActions = !this._emitActions;
@@ -101,6 +101,9 @@ class Manager {
      * Assumes song timer is at zero.
      */
     startSession() {
+        // check if there is an ongoing replay. if so, throw error
+        if (this.replayUtility.isReplaying) throw new Error('Cannot start recording session if actions are being replayed!');
+
         this.actionHistory.startSession();
     }
 
@@ -135,9 +138,6 @@ class Manager {
 
         // pass array to instance of replay util
         this.replayUtility.loadActions(inputArray);
-
-        // check if there is an ongoing session. if so, throw error
-        if (this.actionHistory.sessionStarted) throw new Error('cannot replay if actions are being recorded!');
 
     }
 

--- a/src/utils/ActionEvent.js
+++ b/src/utils/ActionEvent.js
@@ -30,8 +30,8 @@ class ActionEvent {
         } = properties;
 
         // if required props aren't passed, throw error
-        if (!action || !boundKey || !type) {
-            throw new Error('No \'actions\', \'boundKey\', or \'type\' passed to ActionEvent during instantiation!');
+        if (!action || !type) {
+            throw new Error(`No 'action' or 'type' passed to ActionEvent during instantiation! Action: ${action}, Type: ${type}`);
         }
 
         // set current date if no timestamp is passed
@@ -74,7 +74,7 @@ class ActionEvent {
 
     /**
      * Returns a Date object. Represents the time and date the action was performed.
-     * @returns {Date}
+     * @returns {Number}
      */
     get timestamp() {
         return this._timestamp;
@@ -95,7 +95,7 @@ class ActionEvent {
     toString() {
         return `ActionEvent: {
     'type': ${this._type}
-    'actions': ${this._actions}
+    'actions': ${this._action}
     'timestamp': ${this._timestamp}
 }`
     }

--- a/src/utils/ActionHistory.js
+++ b/src/utils/ActionHistory.js
@@ -29,6 +29,14 @@ class ActionHistoryUtil {
     }
 
     /**
+     * Asserts whether a session is already ongoing.
+     * @returns {boolean}
+     */
+    get sessionStarted() {
+        return this._sessionStarted;
+    }
+
+    /**
      * Initializes timer, and allows for recording of sessions.
      * Can only be performed if session has not started.
      *

--- a/src/utils/ReplayUtil.js
+++ b/src/utils/ReplayUtil.js
@@ -1,0 +1,139 @@
+const ActionEvent = require('./ActionEvent');
+
+/**
+ * Wraps code for chaining timeout calls to emit replays.
+ */
+class ReplayUtil {
+
+    /**
+     * Constructor for replay utility. Must be initialized with an emitter function.
+     * This function will be called on every action at the time the action should be performed.
+     *
+     * This is usually passed as some Rx.Subject.next(), but I decided to keep it flexible, because this
+     * code seems useful.
+     *
+     * @param {Function} emitterFunction called with every action event at the time the event is replayed. Only parameter is the `ActionEvent` object itself.
+     * @param {Function} onConclusion called when there are no more inputs
+     */
+    constructor(emitterFunction, onConclusion) {
+
+        // type check
+        if (typeof emitterFunction !== 'function') throw new Error(`Emitter function parameter is of wrong type. Type: ${typeof emitterFunction}.`);
+        if (typeof onConclusion !== 'function') throw new Error(`End of input stream handler (onConclusion) parameter is of wrong type. Type: ${typeof onConclusion}.`);
+
+        this.actions = [];
+        this.emit = emitterFunction;
+        this.onEndOfInputs = onConclusion;
+        this.currentTimeout = null;
+
+        // bind funcs
+        this.emitEventAt = this.emitEventAt.bind(this);
+        this.loadActions = this.loadActions.bind(this);
+        this.terminateReplay = this.terminateReplay.bind(this);
+        this.beginReplay = this.beginReplay.bind(this);
+
+    }
+
+    /**
+     * Emits event at index, and if there is a next move, set an appropriate
+     * timeout for said move.
+     *
+     * @param {Number} index index of the move to be emitted.
+     */
+    emitEventAt(index) {
+
+        // will throw error if indexed out of bounds
+        const currentMove = this.actions[index];
+
+        // emit move
+        this.emit(currentMove);
+
+        // check for next move
+        let nextMove;
+
+        // if index is appropriate
+        if (index + 1 < this.actions.length) {
+
+            // set next move
+            nextMove = this.actions[index + 1];
+
+        }
+
+        // if we have a next move, chain it
+        if (nextMove) {
+
+            this.currentTimeout = setTimeout(
+                this.emitEventAt,
+                nextMove.timestamp - currentMove.timestamp,
+                index + 1
+            );
+
+        } else {
+
+            // if not, call the end function
+            this.onEndOfInputs();
+
+        }
+
+    }
+
+    /**
+     * Loads actions into the module.
+     * @param {Array<ActionEvent>} actionArray events in list should have a timestamp field
+     */
+    loadActions(actionArray) {
+
+        // check for presence of timestamp field
+        actionArray.forEach((action, index) => {
+            if (!action.timestamp) throw new Error(`An action at index ${index} is missing the timestamp field. Aborting.`);
+        });
+
+        // set local variable, convert it to a proper ActionEvent
+        this.actions = actionArray.map(input => new ActionEvent({
+            ...input
+        }));
+
+    }
+
+    /**
+     * Cancels timeout chain. This type of termination (forced) does not call onEndOfInput();
+     */
+    terminateReplay() {
+
+        clearTimeout(this.currentTimeout);
+
+        this.currentTimeout = null;
+
+    }
+
+    /**
+     * Begins timeout chain with the loaded actions. If replay is not forcibly terminated,
+     * the module will call "onEndOfInput" at the end of the stream.
+     */
+    beginReplay() {
+
+        // possibility for pausing? restarting at a given arbitrary input would require accounting for when the pause happened.
+        const beginIndex = 0;
+
+        if (!this.actions || this.actions.length < 1) {
+
+            this.onEndOfInputs();
+
+            return;
+
+        }
+
+        const firstMove = this.actions[beginIndex];
+
+        // begin timeout chain
+        setTimeout(
+            this.emitEventAt,
+            firstMove.timestamp,
+            0
+        );
+
+    }
+
+}
+
+module.exports = ReplayUtil;

--- a/src/utils/ReplayUtil.js
+++ b/src/utils/ReplayUtil.js
@@ -35,6 +35,15 @@ class ReplayUtil {
     }
 
     /**
+     * Getter to determine if replay util is currently replaying.
+     *
+     * @returns {boolean} true if timeout is ongoing, false if timeout has been cleared.
+     */
+    get isReplaying() {
+        return !!this.currentTimeout;
+    }
+
+    /**
      * Emits event at index, and if there is a next move, set an appropriate
      * timeout for said move.
      *
@@ -72,6 +81,7 @@ class ReplayUtil {
 
             // if not, call the end function
             this.onEndOfInputs();
+            this.terminateReplay();
 
         }
 


### PR DESCRIPTION
Replay module added to the input manager.

Initializing a replay requires:

1. Calling `InputManager.loadInputsForReplay(arr)` and passing it an array of objects that contain at least the fields `action` and `timestamp`. The timestamp is required for the chaining, and an error will be thrown if it's missing
2. Calling `InputManager.beginReplay()` --> this will broadcast inputs from the given array as if they being done by a human pressing a keyboard. no difference will be seen from any observers.
3. Calling `InputManager.terminateReplay()` will cancel the replay and restore the IM to it's normal state. This happens naturally when the replay module runs out of inputs to broadcast.

Because I feel like no events are derived from the end of the inputs (one can stop inputting actions waaaay before the song ends) I didn't implement any way to observe the end of input event.